### PR TITLE
fix: Added Console Login with OIDC

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -311,15 +311,17 @@ func BuildOpenIDConsoleConfig() oauth2.OpenIDPCfg {
 	// Only set config if url, clientID, clientSecret and redirectCallback are provided
 	if url != "" && clientID != "" && clientSecret != "" && redirectCallback != "" {
 		pcfg = map[string]oauth2.ProviderConfig{
-			"oauth2": {
+			"OIDC": {
 				URL:                     url,
 				ClientID:                clientID,
 				ClientSecret:            clientSecret,
 				RedirectCallback:        redirectCallback,
 				DisplayName:             env.Get(ConsoleIDPDisplayName, env.Get(MinioIdentifyOpenIDDisplayName, "")),
 				Scopes:                  env.Get(ConsoleIDPScopes, env.Get(MinioIdentifyOpenIDScopes, "openid,profile,email")),
-				Userinfo:                env.Get(ConsoleIDPUserInfo, env.Get(MinioIdentifyOpenClaimUserinfo, "")) == "on",
+				Userinfo:                env.Get(ConsoleIDPUserInfo, env.Get(MinioIdentifyOpenIDClaimUserinfo, "")) == "on",
 				RedirectCallbackDynamic: env.Get(ConsoleIDPCallbackURLDynamic, env.Get(MinioIdentifyOpenIDRedirectURIDynamic, "")) == "on",
+				RoleArn:                 env.Get(ConsoleIDPRolePolicy, env.Get(MinioIdentifyOpenIDRolePolicy, "")),
+				EndSessionEndpoint:      env.Get(ConsoleIDPEndSessionEndpoint, ""),
 			},
 		}
 	}

--- a/api/config.go
+++ b/api/config.go
@@ -299,3 +299,30 @@ func getConsoleDevMode() bool {
 func getConsoleBrowserRedirectURL() string {
 	return env.Get(ConsoleBrowserRedirectURL, "")
 }
+
+func BuildOpenIDConsoleConfig() oauth2.OpenIDPCfg {
+	pcfg := map[string]oauth2.ProviderConfig{}
+
+	url := env.Get(ConsoleIDPURL, env.Get(MinioIdentifyOpenIDConfigURL, ""))
+	clientID := env.Get(ConsoleIDPClientID, env.Get(MinioIdentifyOpenIDClientID, ""))
+	clientSecret := env.Get(ConsoleIDPSecret, env.Get(MinioIdentifyOpenIDClientSecret, ""))
+	redirectCallback := env.Get(ConsoleIDPCallbackURL, env.Get(MinioBrowserRedirectURL, ""))
+
+	// Only set config if url, clientID, clientSecret and redirectCallback are provided
+	if url != "" && clientID != "" && clientSecret != "" && redirectCallback != "" {
+		pcfg = map[string]oauth2.ProviderConfig{
+			"oauth2": {
+				URL:                     url,
+				ClientID:                clientID,
+				ClientSecret:            clientSecret,
+				RedirectCallback:        redirectCallback,
+				DisplayName:             env.Get(ConsoleIDPDisplayName, env.Get(MinioIdentifyOpenIDDisplayName, "")),
+				Scopes:                  env.Get(ConsoleIDPScopes, env.Get(MinioIdentifyOpenIDScopes, "openid,profile,email")),
+				Userinfo:                env.Get(ConsoleIDPUserInfo, env.Get(MinioIdentifyOpenClaimUserinfo, "")) == "on",
+				RedirectCallbackDynamic: env.Get(ConsoleIDPCallbackURLDynamic, env.Get(MinioIdentifyOpenIDRedirectURIDynamic, "")) == "on",
+			},
+		}
+	}
+
+	return pcfg
+}

--- a/api/consts.go
+++ b/api/consts.go
@@ -69,6 +69,8 @@ const (
 	ConsoleIDPCallbackURLDynamic = "CONSOLE_IDP_CALLBACK_DYNAMIC"
 	ConsoleIDPScopes             = "CONSOLE_IDP_SCOPES"
 	ConsoleIDPUserInfo           = "CONSOLE_IDP_USERINFO"
+	ConsoleIDPRolePolicy         = "CONSOLE_IDP_ROLE_POLICY"
+	ConsoleIDPEndSessionEndpoint = "CONSOLE_IDP_END_SESSION_ENDPOINT"
 	// MinIO Server constants for OIDC
 	MinioIdentifyOpenIDDisplayName        = "MINIO_IDENTITY_OPENID_DISPLAY_NAME"
 	MinioIdentifyOpenIDConfigURL          = "MINIO_IDENTITY_OPENID_CONFIG_URL"
@@ -77,5 +79,6 @@ const (
 	MinioBrowserRedirectURL               = "MINIO_BROWSER_REDIRECT_URL"
 	MinioIdentifyOpenIDRedirectURIDynamic = "MINIO_IDENTITY_OPENID_REDIRECT_URI_DYNAMIC"
 	MinioIdentifyOpenIDScopes             = "MINIO_IDENTITY_OPENID_SCOPES"
-	MinioIdentifyOpenClaimUserinfo        = "MINIO_IDENTITY_OPENID_CLAIM_USERINFO"
+	MinioIdentifyOpenIDClaimUserinfo      = "MINIO_IDENTITY_OPENID_CLAIM_USERINFO"
+	MinioIdentifyOpenIDRolePolicy         = "MINIO_IDENTITY_OPENID_ROLE_POLICY"
 )

--- a/api/consts.go
+++ b/api/consts.go
@@ -59,4 +59,23 @@ const (
 	LogSearchQueryAuthToken                      = "LOGSEARCH_QUERY_AUTH_TOKEN"
 	SlashSeparator                               = "/"
 	LocalAddress                                 = "127.0.0.1"
+
+	// Parts of Environment constants for console OIDC/ IDP/SSO as defined in pkg/auth/idp/oath2
+	ConsoleIDPDisplayName        = "CONSOLE_IDP_DISPLAY_NAME"
+	ConsoleIDPURL                = "CONSOLE_IDP_URL"
+	ConsoleIDPClientID           = "CONSOLE_IDP_CLIENT_ID"
+	ConsoleIDPSecret             = "CONSOLE_IDP_SECRET"
+	ConsoleIDPCallbackURL        = "CONSOLE_IDP_CALLBACK"
+	ConsoleIDPCallbackURLDynamic = "CONSOLE_IDP_CALLBACK_DYNAMIC"
+	ConsoleIDPScopes             = "CONSOLE_IDP_SCOPES"
+	ConsoleIDPUserInfo           = "CONSOLE_IDP_USERINFO"
+	// MinIO Server constants for OIDC
+	MinioIdentifyOpenIDDisplayName        = "MINIO_IDENTITY_OPENID_DISPLAY_NAME"
+	MinioIdentifyOpenIDConfigURL          = "MINIO_IDENTITY_OPENID_CONFIG_URL"
+	MinioIdentifyOpenIDClientID           = "MINIO_IDENTITY_OPENID_CLIENT_ID"
+	MinioIdentifyOpenIDClientSecret       = "MINIO_IDENTITY_OPENID_CLIENT_SECRET"
+	MinioBrowserRedirectURL               = "MINIO_BROWSER_REDIRECT_URL"
+	MinioIdentifyOpenIDRedirectURIDynamic = "MINIO_IDENTITY_OPENID_REDIRECT_URI_DYNAMIC"
+	MinioIdentifyOpenIDScopes             = "MINIO_IDENTITY_OPENID_SCOPES"
+	MinioIdentifyOpenClaimUserinfo        = "MINIO_IDENTITY_OPENID_CLAIM_USERINFO"
 )

--- a/cmd/console/server.go
+++ b/cmd/console/server.go
@@ -100,6 +100,11 @@ func buildServer() (*api.Server, error) {
 
 	consoleAPI := operations.NewConsoleAPI(swaggerSpec)
 	consoleAPI.Logger = api.LogInfo
+	// Pass in console application config. This needs to happen before the
+	// ConfigureAPI() call.
+	api.GlobalMinIOConfig = api.MinIOConfig{
+		OpenIDProviders: api.BuildOpenIDConsoleConfig(),
+	}
 	server := api.NewServer(consoleAPI)
 
 	parser := flags.NewParser(server, flags.Default)

--- a/docs/OIDC.md
+++ b/docs/OIDC.md
@@ -1,0 +1,33 @@
+# OIDC
+When the console is running separately and is not embedded in the same binary as the server, the OIDC SSO login configuration is not set from the server.
+
+It needs to be configured using Environment Variables like this:
+``` bash
+export CONSOLE_MINIO_SERVER="http://127.0.0.1:9000";
+
+export CONSOLE_IDP_URL="http://PROVIDER:5556/.well-known/openid-configuration";
+export CONSOLE_IDP_CLIENT_ID="minio-client-app";
+export CONSOLE_IDP_SECRET="minio-client-app-secret";
+export CONSOLE_IDP_CALLBACK="http://CONSOLE:9090/oauth_callback";
+export CONSOLE_IDP_DISPLAY_NAME="Login with OIDC";
+
+./console server
+```
+> [!IMPORTANT]  
+> Currently, the following environment variables are mandatory: `CONSOLE_IDP_URL`, `CONSOLE_IDP_CLIENT_ID`, `CONSOLE_IDP_SECRET` and `CONSOLE_IDP_CALLBACK`.
+
+For convenience, the same environment variables are supported as for the server, with the `CONSOLE_` ones taking precedence over the `MINIO_` ones.  
+This means you can use the same variables as you would set on the server and share them with the console.  
+
+| Console Environment Variables | MinIO Server Environment Variables | Required | Example |
+| -- | -- | -- | -- |
+CONSOLE_IDP_DISPLAY_NAME | MINIO_IDENTITY_OPENID_DISPLAY_NAME | | "Login with OIDC"
+CONSOLE_IDP_URL | MINIO_IDENTITY_OPENID_CONFIG_URL | ✓ | https://provider/.well-known/openid-configuration"
+CONSOLE_IDP_CLIENT_ID | MINIO_IDENTITY_OPENID_CLIENT_ID | ✓ | minio-client-app
+CONSOLE_IDP_SECRET | MINIO_IDENTITY_OPENID_CLIENT_SECRET | ✓ | minio-client-app-secret
+CONSOLE_IDP_CALLBACK | MINIO_BROWSER_REDIRECT_URL | ✓ | https://console/oauth_callback" |
+CONSOLE_IDP_CALLBACK_DYNAMIC | MINIO_IDENTITY_OPENID_REDIRECT_URI_DYNAMIC | | on / off |
+CONSOLE_IDP_SCOPES | MINIO_IDENTITY_OPENID_SCOPES | | "openid,profile,email" 
+CONSOLE_IDP_USERINFO | MINIO_IDENTITY_OPENID_CLAIM_USERINFO | |on / off |
+CONSOLE_IDP_ROLE_POLICY | MINIO_IDENTITY_OPENID_ROLE_POLICY | | "app-bucket-write,app-bucket-list" |
+CONSOLE_IDP_END_SESSION_ENDPOINT | | |


### PR DESCRIPTION
Needs to be configured with Environment Variables like this
``` bash
export CONSOLE_MINIO_SERVER="http://127.0.0.1:9000";
export CONSOLE_IDP_URL="http://dex:5556/dex/.well-known/openid-configuration";
export CONSOLE_IDP_CLIENT_ID="minio-client-app";
export CONSOLE_IDP_SECRET="minio-client-app-secret";
export CONSOLE_IDP_CALLBACK="http://127.0.0.1:9090/oauth_callback";
export CONSOLE_IDP_DISPLAY_NAME="Login Test with OIDC";
./console server
```
Currently URL, CLIENT_ID, SECRET and CALLBACK are needed to be set.

Fixes #6 
- https://github.com/minio/minio/issues/21311
- https://github.com/minio/minio/issues/21415
- https://github.com/minio/minio/issues/21324
- https://github.com/minio/minio/issues/21325
- https://github.com/minio/minio/issues/21394
- https://github.com/minio/minio/issues/21344
- https://github.com/bitnami/containers/issues/82422