### PR TITLE
fix: Set goreleaser bindir for linux packages to /usr/local/bin

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,6 +58,7 @@ nfpms:
     maintainer: "Georg Mangold"
     description: Console UI for MinIO Server
     license: GNU Affero General Public License v3.0
+    bindir: /usr/local/bin
     formats:
       - deb
       - rpm


### PR DESCRIPTION
The default of goreleaser is `/usr/bin`. In the service file of the repo the binary location of `console` is set to `/usr/local/bin/console`. This commit fixes the destination location in goreleaser.

Fixes #62