### PR TITLE
Fix: metrics display for object sizes BETWEEN_1024_B_AND_1_MB

### DIFF
--- a/web-app/src/screens/Console/Dashboard/Prometheus/utils.tsx
+++ b/web-app/src/screens/Console/Dashboard/Prometheus/utils.tsx
@@ -139,7 +139,7 @@ export const panelsConfiguration: IDashboardPanel[] = [
     customStructure: [
       { originTag: "LESS_THAN_1024_B", displayTag: "Less than 1024B" },
       {
-        originTag: "BETWEEN_1024_B_AND_1_MB",
+        originTag: "BETWEEN_1024B_AND_1_MB",
         displayTag: "Between 1024B and 1MB",
       },
       {


### PR DESCRIPTION
Prometheus metric range from minio `BETWEEN_1024B_AND_1_MB` inconsistent with web console looking for `BETWEEN_1024_B_AND_1_MB`

Before
<img width="1091" height="198" alt="Bildschirmfoto vom 2025-11-15 14-04-18" src="https://github.com/user-attachments/assets/52eb507e-76fa-47dd-bf1c-63091f043150" />
After
<img width="1091" height="198" alt="Bildschirmfoto vom 2025-11-15 14-03-49" src="https://github.com/user-attachments/assets/e8e65769-85c7-42ca-951e-9169542922e8" />

fixes: https://github.com/minio/object-browser/issues/3257