### PR TITLE
Fix security vulnerabilities and resolve build configuration issues 

### DIFF
--- a/.github/workflows/vulncheck.yaml
+++ b/.github/workflows/vulncheck.yaml
@@ -10,7 +10,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 env:
-  GO_VERSION: 1.24.9
+  GO_VERSION: 1.24.10
 
 jobs:
   vulncheck:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/console
 
-go 1.24.9
+go 1.24.10
 
 replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.5 // needed for github.com/minio/mc
 

--- a/web-app/knip.config.ts
+++ b/web-app/knip.config.ts
@@ -1,12 +1,12 @@
 import type { KnipConfig } from "knip";
 
 export default {
-  entry: ["src/**/{index,main}.{ts,tsx}", "e2e/**/*.ts", "test/**/*.ts"],
+  entry: ["src/**/{index,main}.{ts,tsx}", "e2e/**/*.ts", "tests/**/*.ts"],
   project: [
     "src/**/*.{ts,tsx}",
     "!src/api/**/*",
     "e2e/**/*.{ts,tsx}",
-    "test/**/*.ts",
+    "tests/**/*.ts",
   ],
   rules: {
     binaries: "error",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -102,7 +102,6 @@
     "jspdf": "^3.0.2",
     "@babel/runtime": "^7.26.10",
     "prebuilt-install": "^2.1.3",
-    "tar-fs": "^2.1.3",
     "form-data": "^4.0.4"
   },
   "overrides": {
@@ -111,6 +110,5 @@
     "tmp": "^0.2.4",
     "on-headers": "^1.0.2"
   },
-  "main": "index.js",
   "packageManager": "yarn@4.9.4"
 }


### PR DESCRIPTION
## What does this do?
* Update Go toolchain to 1.24.10 to address multiple standard library vulnerabilities (GO-2025-4013, GO-2025-4012, GO-2025-4011, GO-2025-4010, GO-2025-4009, GO-2025-4008, GO-2025-4007, GO-2025-3956).
* Update web-app dependencies and remove incorrect package.json main field that was causing knip configuration warnings.

See https://github.com/miniohq/object-browser/pull/2